### PR TITLE
check if the user is loggedin, and hide signout button if not

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           </div>
         </li>
       </ul>
-      <div>
+      <div id="loginContainer">
         <form class="form-inline my-2 my-lg-0">
           <button class="btn btn-outline-success my-2 my-sm-0" type="submit">SignOut</button>
         </form>
@@ -189,5 +189,5 @@
 </body>
 
 <script src="./js/index.js"></script>
-
+<script src="./js/login.js"></script>
 </html>

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,4 @@
+window.loggedIn = localStorage.getItem('user')
+if (!window.loggedIn) {
+  document.getElementById('loginContainer').style.display = 'none'
+}

--- a/src/gallery/index.html
+++ b/src/gallery/index.html
@@ -218,5 +218,5 @@
 <script>
   lightGallery(document.getElementById('lightgallery'))
 </script>
-
+<script src="../../js/login.js"></script>
 </html>


### PR DESCRIPTION
Problem: The signout button is visible even though user is logged out.
Solution: check if the user is logged in based on a key in the localstorage. If the key does not exist, hide the signout button.

Fixes: https://github.com/GangsterTeam/twinkle/issues/48
